### PR TITLE
перевод django.contrib.markup

### DIFF
--- a/locale/ru/LC_MESSAGES/ref/contrib/markup.po
+++ b/locale/ru/LC_MESSAGES/ref/contrib/markup.po
@@ -8,116 +8,82 @@ msgstr ""
 "Project-Id-Version: Django 1.4\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2013-04-23 16:09\n"
-"PO-Revision-Date: 2012-02-15 15:13\n"
-"Last-Translator: Automatically generated\n"
+"PO-Revision-Date: 2013-06-25 15:43+0700\n"
+"Last-Translator: redvi <liberty195@gmail.com>\n"
 "Language-Team: none\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 # 2823617d38c647ba97d08dfcca978663
 #: ../../ref/contrib/markup.txt:3
 msgid "django.contrib.markup"
-msgstr ""
+msgstr "django.contrib.markup"
 
 # 8a315b6c30c048959f93e711ec1caafa
 #: ../../ref/contrib/markup.txt:11
-msgid ""
-"Django provides template filters that implement the following markup "
-"languages:"
-msgstr ""
+msgid "Django provides template filters that implement the following markup languages:"
+msgstr "Django предоставляет шаблонные фильтры, реализующие следующие языки разметки:"
 
 # 175dc3b42a69479b8ed268f93c0a270f
 #: ../../ref/contrib/markup.txt:14
 msgid "``textile`` -- implements `Textile`_ -- requires `PyTextile`_"
-msgstr ""
+msgstr "``textile`` -- реализация `Textile <http://txstyle.org/>`_ -- требует установки `PyTextile <http://loopcore.com/python-textile/>`_"
 
 # 866b7cf0a2214cce91122e83f0b1387b
 #: ../../ref/contrib/markup.txt:15
-msgid ""
-"``markdown`` -- implements `Markdown`_ -- requires `Python-markdown`_ (>=2.1)"
-msgstr ""
+msgid "``markdown`` -- implements `Markdown`_ -- requires `Python-markdown`_ (>=2.1)"
+msgstr "``markdown`` -- реализация `Markdown <http://daringfireball.net/projects/markdown/>`_ -- требует установки `Python-markdown <https://pypi.python.org/pypi/Markdown>`_ (>=2.1)"
 
 # c10b3e6b459946138233881299aa929c
 #: ../../ref/contrib/markup.txt:16
-msgid ""
-"``restructuredtext`` -- implements `reST (reStructured Text)`_ -- requires "
-"`doc-utils`_"
-msgstr ""
+msgid "``restructuredtext`` -- implements `reST (reStructured Text)`_ -- requires `doc-utils`_"
+msgstr "``restructuredtext`` -- реализация `reST (reStructured Text) <http://en.wikipedia.org/wiki/ReStructuredText>`_ -- требует установки `doc-utils <http://docutils.sourceforge.net/>`_"
 
 # 20970d3f9e3b475aa5c3d6946ebbdd70
 #: ../../ref/contrib/markup.txt:19
-msgid ""
-"In each case, the filter expects formatted markup as a string and returns a "
-"string representing the marked-up text. For example, the ``textile`` filter "
-"converts text that is marked-up in Textile format to HTML."
-msgstr ""
+msgid "In each case, the filter expects formatted markup as a string and returns a string representing the marked-up text. For example, the ``textile`` filter converts text that is marked-up in Textile format to HTML."
+msgstr "В каждом из представленных случаев фильтр ожидает получить соответственно отформатированную строку и возвращает строку размеченного текста. Например, фильтр ``textile`` преобразует текст формата Textile в HTML."
 
 # bac848df1cdf46e0b26998e07583934b
 #: ../../ref/contrib/markup.txt:24
-msgid ""
-"To activate these filters, add ``'django.contrib.markup'`` to your :setting:"
-"`INSTALLED_APPS` setting. Once you've done that, use ``{% load markup %}`` "
-"in a template, and you'll have access to these filters. For more "
-"documentation, read the source code in :file:`django/contrib/markup/"
-"templatetags/markup.py`."
-msgstr ""
+msgid "To activate these filters, add ``'django.contrib.markup'`` to your :setting:`INSTALLED_APPS` setting. Once you've done that, use ``{% load markup %}`` in a template, and you'll have access to these filters. For more documentation, read the source code in :file:`django/contrib/markup/templatetags/markup.py`."
+msgstr "Для активации этих фильтров добавьте ``'django.contrib.markup'`` в настройки :setting:`INSTALLED_APPS`. После того как это сделано, используйте в шаблоне ``{% load markup %}``, чтобы получить доступ к фильтру. Для получения дополнительных сведений читайте :file:`django/contrib/markup/templatetags/markup.py`."
 
 # 8891b4635c424b3f8f3e12fb43355ef0
 #: ../../ref/contrib/markup.txt:32
-msgid ""
-"The output of markup filters is marked \"safe\" and will not be escaped when "
-"rendered in a template. Always be careful to sanitize your inputs and make "
-"sure you are not leaving yourself vulnerable to cross-site scripting or "
-"other types of attacks."
-msgstr ""
+msgid "The output of markup filters is marked \"safe\" and will not be escaped when rendered in a template. Always be careful to sanitize your inputs and make sure you are not leaving yourself vulnerable to cross-site scripting or other types of attacks."
+msgstr "На выходе markup фильтр отмечает строки как \"безопасные\" и не экранирует символы HTML при выводе шаблона. Всегда будьте осторожны с фильтрами и проверяйте не оставляют ли они возможности проведения различных видов межсайтовых атак."
 
 # 1d3dab538e984f29a54abd1d3c8ef028
 #: ../../ref/contrib/markup.txt:45
 msgid "reStructured Text"
-msgstr ""
+msgstr "reStructured Text"
 
 # 3ed3e8295e904595b841b3ecc724fa65
 #: ../../ref/contrib/markup.txt:47
-msgid ""
-"When using the ``restructuredtext`` markup filter you can define a :setting:"
-"`RESTRUCTUREDTEXT_FILTER_SETTINGS` in your django settings to override the "
-"default writer settings. See the `restructuredtext writer settings`_ for "
-"details on what these settings are."
-msgstr ""
+msgid "When using the ``restructuredtext`` markup filter you can define a :setting:`RESTRUCTUREDTEXT_FILTER_SETTINGS` in your django settings to override the default writer settings. See the `restructuredtext writer settings`_ for details on what these settings are."
+msgstr "Когда вы используете фильтр  ``restructuredtext`` вы должны определить в настройках :setting:`RESTRUCTUREDTEXT_FILTER_SETTINGS`, чтобы переопределить параметры, установленные по-умолчанию. Для получения подробной информации обратитесь к странице `restructuredtext writer settings <http://docutils.sourceforge.net/docs/user/config.html#html4css1-writer>`_."
 
 # bcd54cfdb8b44e4ea4f82b296f1ee9d0
 #: ../../ref/contrib/markup.txt:54
-msgid ""
-"reStructured Text has features that allow raw HTML to be included, and that "
-"allow arbitrary files to be included. These can lead to XSS vulnerabilities "
-"and leaking of private information. It is your responsibility to check the "
-"features of this library and configure appropriately to avoid this. See the "
-"`Deploying Docutils Securely <http://docutils.sourceforge.net/docs/howto/"
-"security.html>`_ documentation."
-msgstr ""
+msgid "reStructured Text has features that allow raw HTML to be included, and that allow arbitrary files to be included. These can lead to XSS vulnerabilities and leaking of private information. It is your responsibility to check the features of this library and configure appropriately to avoid this. See the `Deploying Docutils Securely <http://docutils.sourceforge.net/docs/howto/security.html>`_ documentation."
+msgstr "reStructured Text имеет свои особенности, благодаря которым возможно включение неэкранированных символов HTML и произвольных файлов. Это может привести к XSS уязвимости и потере приватной информации. Ответственность за проверку возможностей библиотеки и создание корректных настроек во избежание получения уязвимостей ложится на ваши плечи. Обязательно просмотрите следующую документацию: `Deploying Docutils Securely <http://docutils.sourceforge.net/docs/howto/security.html>`_ ."
 
 # b3ce274a7f564c15acac6f3bda2485b9
 #: ../../ref/contrib/markup.txt:64
 msgid "Markdown"
-msgstr ""
+msgstr "Markdown"
 
 # 489479b16ae842fababb4a792b7cfdf4
 #: ../../ref/contrib/markup.txt:66
-msgid ""
-"The Python Markdown library supports options named \"safe_mode\" and "
-"\"enable_attributes\". Both relate to the security of the output. To enable "
-"both options in tandem, the markdown filter supports the \"safe\" argument::"
-msgstr ""
+msgid "The Python Markdown library supports options named \"safe_mode\" and \"enable_attributes\". Both relate to the security of the output. To enable both options in tandem, the markdown filter supports the \"safe\" argument::"
+msgstr "Библиотека Python Markdown поддерживает опции \"safe_mode\" и \"enable_attributes\". Обе эти опции имеют прямое отношение к безопасности. Для их совместного использования markdown поддерживание аргумент \"safe\"::"
 
 # 02f71f58337d4ab3a0bc1e794c93ae8d
 #: ../../ref/contrib/markup.txt:74
-msgid ""
-"Versions of the Python-Markdown library prior to 2.1 do not support the "
-"optional disabling of attributes. This is a security flaw. Therefore, "
-"``django.contrib.markup`` has dropped support for versions of Python-"
-"Markdown < 2.1 in Django 1.5."
-msgstr ""
+msgid "Versions of the Python-Markdown library prior to 2.1 do not support the optional disabling of attributes. This is a security flaw. Therefore, ``django.contrib.markup`` has dropped support for versions of Python-Markdown < 2.1 in Django 1.5."
+msgstr "Python-Markdown до версии 2.1 не поддерживает опциональное отключение опций. Это брешь в безопасности. Поэтому поддержка Python-Markdown < 2.1 была прекращена в Django 1.5."
+


### PR DESCRIPTION
Добавлен перевод страницы http://djbook.ru/rel1.5/ref/contrib/markup.html?highlight=markup#django.contrib.markup
