### PR TITLE
Remove missprint from translation

### DIFF
--- a/locale/ru/LC_MESSAGES/misc/design-philosophies.po
+++ b/locale/ru/LC_MESSAGES/misc/design-philosophies.po
@@ -239,7 +239,7 @@ msgstr "Главные задачи ядра баз данных:"
 # 55c29ae1b5f448a59996db6a694e9742
 #: ../../misc/design-philosophies.txt:121
 msgid "SQL efficiency"
-msgstr "Еффективность SQL"
+msgstr "Эффективность SQL"
 
 # a771a56a7b494923842ddc52a51dfc22
 #: ../../misc/design-philosophies.txt:123


### PR DESCRIPTION
I exchange "Е" symbol by "Э"